### PR TITLE
Chart reference changes for gitops migration

### DIFF
--- a/gitops/README.md
+++ b/gitops/README.md
@@ -41,7 +41,7 @@ export Git_Url=[your git url]
 export Git_Branch=[your git branch]
 
 # Set your target directory git path. This is the path Flux will look for yaml to be applied in the cluster.
-# example: export Git_Path=ngsa-cd/deployments/preprod/central\\,ngsa-cd/deployments/preprod/common
+# example: export Git_Path=gitops/deployments/preprod/central\\,gitops/deployments/preprod/common
 export Git_Path=[your git path]
 
 

--- a/gitops/deployments/dev/ngsa-cosmos.yaml
+++ b/gitops/deployments/dev/ngsa-cosmos.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   releaseName: ngsa-cosmos
   chart:
-    git: git@github.com:retaildevcrews/ngsa-cd
-    path: charts/ngsa
+    git: git@github.com:retaildevcrews/ngsa
+    path: gitops/charts/ngsa
     ref: main
   values:
     app:

--- a/gitops/deployments/dev/ngsa-memory.yaml
+++ b/gitops/deployments/dev/ngsa-memory.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   releaseName: ngsa-memory
   chart:
-    git: git@github.com:retaildevcrews/ngsa-cd
-    path: charts/ngsa
+    git: git@github.com:retaildevcrews/ngsa
+    path: gitops/charts/ngsa
     ref: main
   values:
     app:

--- a/gitops/deployments/preprod/central/ngsa-cosmos.yaml
+++ b/gitops/deployments/preprod/central/ngsa-cosmos.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   releaseName: ngsa-cosmos
   chart:
-    git: git@github.com:retaildevcrews/ngsa-cd
-    path: charts/ngsa
+    git: git@github.com:retaildevcrews/ngsa
+    path: gitops/charts/ngsa
     ref: main
   values:
     app:

--- a/gitops/deployments/preprod/central/ngsa-memory.yaml
+++ b/gitops/deployments/preprod/central/ngsa-memory.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   releaseName: ngsa-memory
   chart:
-    git: git@github.com:retaildevcrews/ngsa-cd
-    path: charts/ngsa
+    git: git@github.com:retaildevcrews/ngsa
+    path: gitops/charts/ngsa
     ref: main
   values:
     app:

--- a/gitops/deployments/preprod/east/ngsa-cosmos.yaml
+++ b/gitops/deployments/preprod/east/ngsa-cosmos.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   releaseName: ngsa-cosmos
   chart:
-    git: git@github.com:retaildevcrews/ngsa-cd
-    path: charts/ngsa
+    git: git@github.com:retaildevcrews/ngsa
+    path: gitops/charts/ngsa
     ref: main
   values:
     app:

--- a/gitops/deployments/preprod/east/ngsa-memory.yaml
+++ b/gitops/deployments/preprod/east/ngsa-memory.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   releaseName: ngsa-memory
   chart:
-    git: git@github.com:retaildevcrews/ngsa-cd
-    path: charts/ngsa
+    git: git@github.com:retaildevcrews/ngsa
+    path: gitops/charts/ngsa
     ref: main
   values:
     app:

--- a/gitops/deployments/preprod/west/ngsa-cosmos.yaml
+++ b/gitops/deployments/preprod/west/ngsa-cosmos.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   releaseName: ngsa-cosmos
   chart:
-    git: git@github.com:retaildevcrews/ngsa-cd
-    path: charts/ngsa
+    git: git@github.com:retaildevcrews/ngsa
+    path: gitops/charts/ngsa
     ref: main
   values:
     app:

--- a/gitops/deployments/preprod/west/ngsa-memory.yaml
+++ b/gitops/deployments/preprod/west/ngsa-memory.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   releaseName: ngsa-memory
   chart:
-    git: git@github.com:retaildevcrews/ngsa-cd
-    path: charts/ngsa
+    git: git@github.com:retaildevcrews/ngsa
+    path: gitops/charts/ngsa
     ref: main
   values:
     app:


### PR DESCRIPTION
# Type of PR
- [x] CI-CD changes

## Purpose of PR
For HelmRelease files, updated the helm chart reference to point to chart in ngsa repo instead of ngsa-cd

## Validation
- [x] Update documentation or issue referenced above
