### PR TITLE
Turn off KEDA autoscaling for DEV Helm deployment 

### DIFF
--- a/gitops/deployments/dev/ngsa-cosmos.yaml
+++ b/gitops/deployments/dev/ngsa-cosmos.yaml
@@ -14,6 +14,8 @@ spec:
     path: gitops/charts/ngsa
     ref: main
   values:
+    autoscaling:
+      enabled: false
     app:
       args:
       - --no-cache

--- a/gitops/deployments/dev/ngsa-memory.yaml
+++ b/gitops/deployments/dev/ngsa-memory.yaml
@@ -14,6 +14,8 @@ spec:
     path: gitops/charts/ngsa
     ref: main
   values:
+    autoscaling:
+      enabled: false  
     app:
       args:
       - --in-memory


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [x] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Turn off  KEDA autoscaling for `DEV` Helm deployment as an effort to stabilize the system

We started with Dev to test the change and if works I will disable autoscaling  for pre-prod a separate PR will be created.

## Issues Closed or Referenced

- References #535 
