### PR TITLE
Turn off KEDA autoscaling for PRE-PROD Helm deployment

### DIFF
--- a/gitops/deployments/preprod/central/ngsa-cosmos.yaml
+++ b/gitops/deployments/preprod/central/ngsa-cosmos.yaml
@@ -14,6 +14,8 @@ spec:
     path: gitops/charts/ngsa
     ref: main
   values:
+    autoscaling:
+      enabled: false
     app:
       args:
       - --no-cache

--- a/gitops/deployments/preprod/central/ngsa-memory.yaml
+++ b/gitops/deployments/preprod/central/ngsa-memory.yaml
@@ -14,6 +14,8 @@ spec:
     path: gitops/charts/ngsa
     ref: main
   values:
+    autoscaling:
+      enabled: false
     app:
       args:
       - --in-memory

--- a/gitops/deployments/preprod/east/ngsa-cosmos.yaml
+++ b/gitops/deployments/preprod/east/ngsa-cosmos.yaml
@@ -14,6 +14,8 @@ spec:
     path: gitops/charts/ngsa
     ref: main
   values:
+    autoscaling:
+      enabled: false  
     app:
       args:
       - -a

--- a/gitops/deployments/preprod/east/ngsa-memory.yaml
+++ b/gitops/deployments/preprod/east/ngsa-memory.yaml
@@ -14,6 +14,8 @@ spec:
     path: gitops/charts/ngsa
     ref: main
   values:
+    autoscaling:
+      enabled: false  
     app:
       args:
       - --in-memory

--- a/gitops/deployments/preprod/west/ngsa-cosmos.yaml
+++ b/gitops/deployments/preprod/west/ngsa-cosmos.yaml
@@ -14,6 +14,8 @@ spec:
     path: gitops/charts/ngsa
     ref: main
   values:
+    autoscaling:
+      enabled: false  
     app:
       args:
       - -a

--- a/gitops/deployments/preprod/west/ngsa-memory.yaml
+++ b/gitops/deployments/preprod/west/ngsa-memory.yaml
@@ -14,6 +14,8 @@ spec:
     path: gitops/charts/ngsa
     ref: main
   values:
+    autoscaling:
+      enabled: false  
     app:
       args:
       - --in-memory


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [X] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

Turn off KEDA autoscaling for `PRE-PROD Helm deployment as an effort to stabilize the system

## Issues Closed or Referenced

- Closes #535 
