### PR TITLE
[Spike Bugfix] Added 'default' namespace to OMS Config

### DIFF
--- a/spikes/oms-log-analytics/3-container-azm-ms-agentconfig.yaml
+++ b/spikes/oms-log-analytics/3-container-azm-ms-agentconfig.yaml
@@ -74,7 +74,7 @@ data:
         ## Restricts Kubernetes monitoring to namespaces for pods that have annotations set and are scraped using the monitor_kubernetes_pods setting.
         ## This will take effect when monitor_kubernetes_pods is set to true
         ##   ex: monitor_kubernetes_pods_namespaces = ["default1", "default2", "default3"]
-        # monitor_kubernetes_pods_namespaces = ["default1"]
+        monitor_kubernetes_pods_namespaces = ["default"]
 
     [prometheus_data_collection_settings.node]
         # Node level scrape endpoint(s). These metrics will be scraped from agent's DaemonSet running in every node in the cluster


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
OMS Bugfix. Forgot to add default namespace to scrape off prometheus data

## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes #issue_number (this will automatically close the issue when the PR closes)
- References #issue_number (this references the issue but does not close with PR)
