### PR TITLE
Cleanup of AKS cluster deployment

### DIFF
--- a/IaC/AKS/README.md
+++ b/IaC/AKS/README.md
@@ -419,7 +419,7 @@ kubectl create namespace ngsa-l8r
 
 cp ./loderunner/helm-config.example.yaml ./loderunner/helm-config.yaml
 
-helm install l8r loderunner -f ./loderunner/helm-config.yaml --namespace ngsa-l8r
+helm install l8r loderunner -f ./loderunner/helm-config.yaml --namespace ngsa-l8r --set region=$Ngsa_Location
 
 # Verify the pods are running
 kubectl get pods --namespace ngsa-l8r

--- a/IaC/AKS/cluster/charts/loderunner/helm-config.example.yaml
+++ b/IaC/AKS/cluster/charts/loderunner/helm-config.example.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 ingressURLs:
-  - http://ngsa-aks.ngsa.svc.cluster.local:4120
+  - http://ngsa-aks.ngsa.svc.cluster.local:8080
 
 region: "Debug"
 zone: "Debug"


### PR DESCRIPTION
# Type of PR

- [X] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

While walking through the AKS cluster deployment README, I found two issues that this PR addresses:

1. The wrong port number in the load runner deployment. The app `ngsa-aks` is exposed on port 8080
2. Region is set to debug in for the deployment of l8r, so this uses the existing environment variable to set the region

## Validation

- [ ] Unit tests updated and ran successfully
- [X] Update documentation or issue referenced above

## Issues Closed or Referenced

Closes #574 
