### PR TITLE
Use Cosmos read-write key instead of read only for CRUD support

### DIFF
--- a/IaC/AKS/README.md
+++ b/IaC/AKS/README.md
@@ -338,7 +338,7 @@ kubectl create secret generic ngsa-secrets \
   --namespace ngsa \
   --from-literal=CosmosDatabase=$Imdb_DB \
   --from-literal=CosmosCollection=$Imdb_Col \
-  --from-literal=CosmosKey=$(az cosmosdb keys list -n $Imdb_Name -g $Imdb_RG --query primaryReadonlyMasterKey -o tsv) \
+  --from-literal=CosmosKey=$(az cosmosdb keys list -n $Imdb_Name -g $Imdb_RG --query primaryMasterKey -o tsv) \
   --from-literal=CosmosUrl=https://${Imdb_Name}.documents.azure.com:443/
 
 ```

--- a/IaC/AKS/scripts/create-cluster-env.bash
+++ b/IaC/AKS/scripts/create-cluster-env.bash
@@ -224,7 +224,7 @@ else
     Imdb_RW_Key=$(az cosmosdb keys list -n $Imdb_Name -g $Imdb_RG --query primaryMasterKey -o tsv ${subs_arg})
     docker run -it --rm retaildevcrew/imdb-import $Imdb_Name ${Imdb_RW_Key} $Imdb_DB $Imdb_Col
     ## Finished Loading IMDB
-    Ngsa_Imdb_CM_Key=$(az cosmosdb keys list -n $Imdb_Name -g $Imdb_RG --query primaryReadonlyMasterKey -o tsv ${subs_arg})
+    Ngsa_Imdb_CM_Key=$Imdb_RW_Key
     Ngsa_Imdb_CM_Url=https://${Imdb_Name}.documents.azure.com:443/
 fi
 

--- a/IaC/DevCluster/cheatsheet.txt
+++ b/IaC/DevCluster/cheatsheet.txt
@@ -25,13 +25,13 @@ sudo cp -R grafanadata/. /grafana
 sudo chown -R 472:472 /grafana
 
 # check az access
-az cosmosdb keys list -n ngsa-pre-cosmos -g ngsa-pre-shared-rg --query primaryReadonlyMasterKey --subscription bartr-wcnp -o tsv
+az cosmosdb keys list -n ngsa-pre-cosmos -g ngsa-pre-shared-rg --query primaryMasterKey --subscription bartr-wcnp -o tsv
 
 # requires access to bartr-wcnp subscription
 kubectl create secret generic ngsa-secrets \
   --from-literal=CosmosDatabase=imdb \
   --from-literal=CosmosCollection=movies \
-  --from-literal=CosmosKey=$(az cosmosdb keys list -n ngsa-pre-cosmos -g ngsa-pre-shared-rg --query primaryReadonlyMasterKey --subscription bartr-wcnp -o tsv) \
+  --from-literal=CosmosKey=$(az cosmosdb keys list -n ngsa-pre-cosmos -g ngsa-pre-shared-rg --query primaryMasterKey --subscription bartr-wcnp -o tsv) \
   --from-literal=CosmosUrl=https://ngsa-pre-cosmos.documents.azure.com:443/ \
  
 # dev-logs

--- a/IaC/DevCluster/ngsa-cosmos/README.md
+++ b/IaC/DevCluster/ngsa-cosmos/README.md
@@ -24,7 +24,7 @@ env | grep Imdb_
 kubectl create secret generic ngsa-secrets \
   --from-literal=CosmosDatabase=$Imdb_DB \
   --from-literal=CosmosCollection=$Imdb_Col \
-  --from-literal=CosmosKey=$(az cosmosdb keys list -n $Imdb_Name -g $Imdb_RG --query primaryReadonlyMasterKey -o tsv) \
+  --from-literal=CosmosKey=$(az cosmosdb keys list -n $Imdb_Name -g $Imdb_RG --query primaryMasterKey -o tsv) \
   --from-literal=CosmosUrl=https://${Imdb_Name}.documents.azure.com:443/
 
 # display the secrets (base 64 encoded)

--- a/docs/MovingPreProdCluster.md
+++ b/docs/MovingPreProdCluster.md
@@ -142,7 +142,7 @@ kubectl create secret generic ngsa-secrets \
         --namespace ngsa \
         --from-literal=CosmosDatabase=imdb \
         --from-literal=CosmosCollection=movies \
-        --from-literal=CosmosKey=$(az cosmosdb keys list -n ngsa-pre-west-cosmos -g ngsa-pre-west-cosmos-rg --query primaryReadonlyMasterKey -o tsv) \
+        --from-literal=CosmosKey=$(az cosmosdb keys list -n ngsa-pre-west-cosmos -g ngsa-pre-west-cosmos-rg --query primaryMasterKey -o tsv) \
         --from-literal=CosmosUrl=https://ngsa-pre-west-cosmos.documents.azure.com:443/
 
 kubectl create namespace fluentbit

--- a/spikes/aks-secure-baseline/README.md
+++ b/spikes/aks-secure-baseline/README.md
@@ -151,7 +151,7 @@ export AKS_NAME=<aks cluster name>
 az keyvault secret set -o table --vault-name $KEYVAULT_NAME --name "CosmosDatabase" --value $Imdb_DB
 az keyvault secret set -o table --vault-name $KEYVAULT_NAME --name "CosmosCollection" --value $Imdb_Col
 az keyvault secret set -o table --vault-name $KEYVAULT_NAME --name "CosmosKey" \
-  --value $(az cosmosdb keys list -n $Imdb_Name -g $Imdb_RG --query primaryReadonlyMasterKey -o tsv)
+  --value $(az cosmosdb keys list -n $Imdb_Name -g $Imdb_RG --query primaryMasterKey -o tsv)
 az keyvault secret set -o table --vault-name $KEYVAULT_NAME --name "CosmosUrl" --value https://${Imdb_Name}.documents.azure.com:443/
 
 # create managed identity for NGSA


### PR DESCRIPTION
# Type of PR

- [x] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
With NGSA CRUD support making moves, changing the documentation and any references to use the cosmos read-write key instead of read-only

## Issues Closed or Referenced

- References https://github.com/retaildevcrews/wcnp/issues/59
