### PR TITLE
Adjust threshold alerts to reduce triggered frequently. 

### DIFF
--- a/docs/alerts/HighClientResponseTimeWestUS2-cosmos.json
+++ b/docs/alerts/HighClientResponseTimeWestUS2-cosmos.json
@@ -19,11 +19,11 @@
             "threshold": 4,
             "thresholdOperator": "GreaterThan"
           },
-          "threshold": 105,
+          "threshold": 178,
           "thresholdOperator": "GreaterThan"
         }
       },
-      "description": "Client response time is  > 105ms",
+      "description": "Client response time is  > 178ms",
       "displayName": "HighClientResponseTimeWestUS2-cosmos",
       "enabled": "true",
       "schedule": {

--- a/docs/alerts/HighServerResponseTimeWestUS2-cosmos.json
+++ b/docs/alerts/HighServerResponseTimeWestUS2-cosmos.json
@@ -19,11 +19,11 @@
             "threshold": 4,
             "thresholdOperator": "GreaterThan"
           },
-          "threshold": 100,
+          "threshold": 175,
           "thresholdOperator": "GreaterThan"
         }
       },
-      "description": "Server response time is  > 100ms",
+      "description": "Server response time is  > 175ms",
       "displayName": "HighServerResponseTimeWestUS2-cosmos",
       "enabled": "true",
       "schedule": {


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes
- [x] Observability

## Purpose of PR
Ngsa code has changed and we encountered that Alerts "HighClientResponseTimeWestUS2-cosmos" and "HighServerResponseTimeWestUS2-cosmos" triggered more frequently. 

So with this PR we are adjusting the threshold value accordingly based on last 2 weeks data. 

## Issues Closed or Referenced

- References #287 
