### PR TITLE
Update alert threshold for eastus2 cosmos from 130ms to 200ms

### DIFF
--- a/docs/alerts/HighClientResponseTimeEastUS2-cosmos.json
+++ b/docs/alerts/HighClientResponseTimeEastUS2-cosmos.json
@@ -19,11 +19,11 @@
           "threshold": 4,
           "thresholdOperator": "GreaterThan"
         },
-        "threshold": 130,
+        "threshold": 200,
         "thresholdOperator": "GreaterThan"
       }
     },
-    "description": "Client response time is  > 130ms",
+    "description": "Client response time is  > 200ms",
     "displayName": "HighClientResponseTimeEastUS2-cosmos",
     "enabled": "true",
     "schedule": {

--- a/docs/alerts/HighServerResponseTimeEastUS2-cosmos.json
+++ b/docs/alerts/HighServerResponseTimeEastUS2-cosmos.json
@@ -19,11 +19,11 @@
             "threshold": 4,
             "thresholdOperator": "GreaterThan"
           },
-          "threshold": 130,
+          "threshold": 200,
           "thresholdOperator": "GreaterThan"
         }
       },
-      "description": "Server response time is  > 130ms",
+      "description": "Server response time is  > 200ms",
       "displayName": "HighServerResponseTimeEastUS2-cosmos",
       "enabled": "true",
       "schedule": {

--- a/docs/alerts/updatealerts.sh
+++ b/docs/alerts/updatealerts.sh
@@ -13,7 +13,7 @@ for filename in ./*.json; do
 
   # create or update alert
   az rest --method PUT --url "https://management.azure.com/subscriptions/$(eval ${Ngsa_Sub})/resourceGroups/${Ngsa_Log_Analytics_RG}/providers/microsoft.insights/scheduledqueryrules/${Alert_Name}?api-version=2018-04-16" --body @$filename-temp.json &> /dev/null
-  
+
   # remove temporary file
   rm $filename-temp.json
 


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

Update alerts threshold for eastus2 cosmos from 130ms to 200ms. The goal is to let this setting run for a few weeks and collect data. After that, we'll review the response times, the number of alerts fired, and update the threshold again if needed.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/ngsa/issues/784
