### PR TITLE
Update alert threshold for westus2 cosmos from 178ms to 200ms

### DIFF
--- a/docs/alerts/HighClientResponseTimeWestUS2-cosmos.json
+++ b/docs/alerts/HighClientResponseTimeWestUS2-cosmos.json
@@ -19,11 +19,11 @@
             "threshold": 4,
             "thresholdOperator": "GreaterThan"
           },
-          "threshold": 178,
+          "threshold": 200,
           "thresholdOperator": "GreaterThan"
         }
       },
-      "description": "Client response time is  > 178ms",
+      "description": "Client response time is  > 200ms",
       "displayName": "HighClientResponseTimeWestUS2-cosmos",
       "enabled": "true",
       "schedule": {

--- a/docs/alerts/HighServerResponseTimeWestUS2-cosmos.json
+++ b/docs/alerts/HighServerResponseTimeWestUS2-cosmos.json
@@ -19,11 +19,11 @@
             "threshold": 4,
             "thresholdOperator": "GreaterThan"
           },
-          "threshold": 175,
+          "threshold": 200,
           "thresholdOperator": "GreaterThan"
         }
       },
-      "description": "Server response time is  > 175ms",
+      "description": "Server response time is  > 200ms",
       "displayName": "HighServerResponseTimeWestUS2-cosmos",
       "enabled": "true",
       "schedule": {


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Update alerts threshold for eastus2 cosmos from 178ms to 200ms. The goal is to let this setting run for a few weeks and collect data. After that, we'll review the response times, the number of alerts fired, and update the threshold again if needed.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes #787 
- References #784 
